### PR TITLE
Fix Helper Scripts and remove stateful project id's

### DIFF
--- a/helpers/cleanup.sh
+++ b/helpers/cleanup.sh
@@ -71,6 +71,11 @@ gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
 
 gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
     --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --role="roles/iam.serviceAccountUser" \
+    --user-output-enabled false
+
+gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
+    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
     --role="roles/storage.admin" \
     --user-output-enabled false
 

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -83,6 +83,11 @@ gcloud projects add-iam-policy-binding ${PROJECT_ID} \
     --role="roles/serviceusage.serviceUsageAdmin" \
     --user-output-enabled false
 
+gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
+    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --role="roles/iam.serviceAccountUser" \
+    --user-output-enabled false
+
 gcloud projects add-iam-policy-binding ${PROJECT_ID} \
     --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
     --role="roles/storage.admin" \

--- a/main.tf
+++ b/main.tf
@@ -74,17 +74,12 @@ resource "null_resource" "get_repo" {
    Forseti execution
  *******************************************/
 resource "null_resource" "execute_forseti" {
-  # First, set the project in gcloud config
-  provisioner "local-exec" {
-    command = "gcloud config set project ${local.project_id}"
-  }
-
-  # Then, execute forseti installation
+  # Execute forseti installation
   provisioner "local-exec" {
     command = "cd forseti-security; ${local.launch_command_fmt}"
 
     environment {
-      CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE = "${var.credentials_file_path}"
+      CLOUDSDK_CORE_PROJECT = "${local.project_id}"
     }
   }
 


### PR DESCRIPTION
The helper scripts never provision/deprovision the SA to include the Service Account User role which is leading to some unexpected behavior when installing Forseti. Updated the helper scripts to include this role.

Additionally, the Forseti module currently statefully sets the project id using the gcloud command:

gcloud config set project ${local.project_id}

Removed this functionality and replaced with the CLOUDSDK_CORE_PROJECT environment variable.