### PR TITLE
Correcting service-account script, adding a script to automate the in…

### DIFF
--- a/accScript.sh
+++ b/accScript.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Author: luciano.bastet@globant.com                        #
+# This script replace raw_input for the owner email account #
+# in the Forsety Security installer Script to automate      #
+# the installation with Terraform                           #
+  
+
+sed -i '/self.config.gsuite_superadmin_email = raw_input(/c\\tself.config.gsuite_superadmin_email = '\"$1\"'' forseti-security/install/gcp/installer/forseti_server_installer.py
+sed -i '/constants.QUESTION_GSUITE_SUPERADMIN_EMAIL).strip()/c\' forseti-security/install/gcp/installer/forseti_server_installer.py

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -22,7 +22,7 @@ then
     exit 1;
 fi
 
-ORG_ID="$(gcloud organizations list --format="value(ID) --filter="$2"")"
+ORG_ID="$(gcloud organizations list --format="value(ID)" --filter="$2")"
 
 if [[ $ORG_ID == "" ]];
 then

--- a/main.tf
+++ b/main.tf
@@ -33,13 +33,14 @@ locals {
     "deploymentmanager.googleapis.com",
     "iam.googleapis.com",
   ]
-
-  launch_command_main        = "python install/gcp_installer.py --no-cloudshell --service-account-key-file ${var.credentials_file_path} --gsuite-superadmin-email ${var.gsuite_admin_email}"
+  /*COMMAND TO REPLACE SCRIPT FOR AUTOMATION*/
+  launch_first		     = "sh scripts/accScript.sh ${var.gsuite_admin_email}; "
+  launch_command_main        = "cd forseti-security; python install/gcp_installer.py --no-cloudshell --service-account-key-file ${var.credentials_file_path} --gsuite-superadmin-email ${var.gsuite_admin_email}"
   launch_command_gcs         = "${var.gcs_location != "" ? format("--gcs-location %s", var.gcs_location) : "--gcs-location \"\""}"
   launch_command_cloudsql    = "${var.cloud_sql_region != "" ? format("--cloudsql-region %s", var.cloud_sql_region) : "--cloudsql-region \"\"" }"
   launch_command_sendgrid    = "${var.sendgrid_api_key != "" ? format("--sendgrid-api-key %s", var.sendgrid_api_key) : "--skip-sendgrid-config" }"
   launch_command_email_notif = "${var.notification_recipient_email != "" && !local.skip_sendgrid_config ? format("--notification-recipient-email %s", var.notification_recipient_email) : ""}"
-  launch_command_list        = "${compact(list(local.launch_command_main, local.launch_command_sendgrid, local.launch_command_cloudsql, local.launch_command_email_notif, local.launch_command_gcs))}"
+  launch_command_list        = "${compact(list(local.launch_first, local.launch_command_main, local.launch_command_sendgrid, local.launch_command_cloudsql, local.launch_command_email_notif, local.launch_command_gcs))}"
   launch_command_fmt         = "${join(" ", local.launch_command_list)}"
 }
 
@@ -76,7 +77,7 @@ resource "null_resource" "get_repo" {
 resource "null_resource" "execute_forseti" {
   # Execute forseti installation
   provisioner "local-exec" {
-    command = "cd forseti-security; ${local.launch_command_fmt}"
+    command = "${local.launch_command_fmt}"
 
     environment {
       CLOUDSDK_CORE_PROJECT = "${local.project_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -36,14 +36,17 @@ variable "sendgrid_api_key" {
 
 variable "notification_recipient_email" {
   description = "Notification recipient email"
+  default = ""
 }
 
 variable "gsuite_admin_email" {
   description = "The email of a GSuite super admin, used for pulling user directory information."
+  default = ""
 }
 
 variable "project_id" {
   description = "The ID of the project where Forseti will be installed"
+  default = ""
 }
 
 variable "forseti_repo_url" {
@@ -58,4 +61,5 @@ variable "forseti_repo_branch" {
 
 variable "credentials_file_path" {
   description = "Path to service account json"
+  default = ""
 }


### PR DESCRIPTION
To fully automate the installation with Terraform I create a script that changes to lines of Forseti Security installer that wants to received a raw_input from the keyboard to get the var of variable.tf regarding the email owner account. On the other hand, I correct a mistake of the helper/setup.sh script of double quotes that was wrong place. Best regards