### PR TITLE
[docs] Change source reference in README to reflect registry source address

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple setup is provided in the examples folder; however, the usage of the mod
       Forseti Module Install
      *****************************************/
     module "forseti-install-simple" {
-      source                       = "github.com/terraform-google-modules/terraform-google-forseti"
+      source                       = "terraform-google-modules/forseti/google"
       gsuite_admin_email           = "superadmin@yourdomain.com"
       project_id                   = "my-forseti-project"
       download_forseti             = "true"


### PR DESCRIPTION

This PR changes the github source referenced in the README example docs to a standard registry source address to reference the published registry module.
