### PR TITLE
Upload Forseti rules, don't continue to manage

### DIFF
--- a/modules/rules/main.tf
+++ b/modules/rules/main.tf
@@ -55,4 +55,8 @@ resource "google_storage_bucket_object" "main" {
   name    = "${element(local.files, count.index)}"
   content = "${element(data.template_file.main.*.rendered, count.index)}"
   bucket  = "${var.bucket}"
+
+  lifecycle {
+    ignore_changes = ["content", "detect_md5hash"]
+  }
 }


### PR DESCRIPTION
Terraform should upload the Forseti ruleset but should be hands-off
after the initial upload; users will be modifying those rules and we
don't want to overwrite their changes.