### PR TITLE
Never prompt during Forseti instance upgrades

### DIFF
--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -1,10 +1,8 @@
 #!/bin/bash
-exec > /tmp/deployment.log
-exec 2>&1
 
 # Ubuntu update.
 sudo apt-get update -y
-sudo apt-get upgrade -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 
 # Forseti setup.
 sudo apt-get install -y git unzip

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -1,11 +1,10 @@
 #!/bin/bash
-exec > /tmp/deployment.log
-exec 2>&1
 
 # Ubuntu update.
 sudo apt-get update -y
-sudo apt-get upgrade -y
-sudo apt-get update && sudo apt-get --assume-yes install google-cloud-sdk
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+sudo apt-get update -y
+sudo apt-get --assume-yes install google-cloud-sdk
 
 # Env variables
 USER_HOME=/home/ubuntu


### PR DESCRIPTION
When the Forseti client and server instances were running updates on
startup, it was possible for apt/dpkg to prompt for input during the
upgrade process. Since there's no tty attached to the associated process
this would cause the startup script to hang.

This commit modifies the invocation of `apt-get update` to never prompt,
update default conffiles, and use the original file when a non-default
file is present.