### PR TITLE
Rebuild Forseti server instance on server config change

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -72,15 +72,16 @@ data "template_file" "forseti_server_startup_script" {
   template = "${local.server_startup_script}"
 
   vars {
-    forseti_environment      = "${data.template_file.forseti_server_environment.rendered}"
-    forseti_env              = "${data.template_file.forseti_server_env.rendered}"
-    forseti_run_frequency    = "${var.forseti_run_frequency}"
-    forseti_repo_url         = "${var.forseti_repo_url}"
-    forseti_version          = "${var.forseti_version}"
-    forseti_server_conf_path = "${local.server_conf_path}"
-    forseti_home             = "${var.forseti_home}"
-    cloudsql_proxy_arch      = "${var.cloudsql_proxy_arch}"
-    storage_bucket_name      = "${local.server_bucket_name}"
+    forseti_environment          = "${data.template_file.forseti_server_environment.rendered}"
+    forseti_env                  = "${data.template_file.forseti_server_env.rendered}"
+    forseti_run_frequency        = "${var.forseti_run_frequency}"
+    forseti_repo_url             = "${var.forseti_repo_url}"
+    forseti_version              = "${var.forseti_version}"
+    forseti_server_conf_path     = "${local.server_conf_path}"
+    forseti_home                 = "${var.forseti_home}"
+    cloudsql_proxy_arch          = "${var.cloudsql_proxy_arch}"
+    storage_bucket_name          = "${local.server_bucket_name}"
+    forseti_conf_server_checksum = "${base64sha256(data.template_file.forseti_server_config.rendered)}"
   }
 }
 

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# forseti_conf_server digest: ${forseti_conf_server_checksum}
+# This digest is included in the startup script to rebuild the Forseti server VM
+# whenever the server configuration changes.
+
 # Ubuntu update.
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade


### PR DESCRIPTION
This commit injects the digest of the `forseti_conf_server.yaml`
configuration file into the Forseti server startup script. When the
configuration file changes it will introduce a change into the startup
script; this change will cause the Forseti server instance to be rebuilt
and automatically pick up changes to the server configuration file.