### PR TITLE
Add `forseti inventory list` to server host integration tests

### DIFF
--- a/test/integration/simple_example/controls/server.rb
+++ b/test/integration/simple_example/controls/server.rb
@@ -24,6 +24,10 @@ control 'server' do
     its('exit_status') { should eq 0 }
   end
 
+  describe command("forseti inventory list") do
+    its('exit_status') { should eq 0 }
+  end
+
   describe command('forseti_server') do
     it { should exist }
   end


### PR DESCRIPTION
Previously the Forseti server host integration tests were checking that the server configuration could be fetched but didn't perform any operations that would force a query to be made all the way from the Forseti client process, through the server, to the backing database.  This commit adds a call to `forseti inventory list` to test that flow of execution, which will give us a bit more confidence in the Forseti installation.