### PR TITLE
Install forseti pip requirements on client instance

### DIFF
--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -1,17 +1,14 @@
 #!/bin/bash
 
+# Env variables
+USER=ubuntu
+USER_HOME=/home/ubuntu
+
 # Ubuntu update.
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
-
-# Forseti setup.
-sudo apt-get install -y git unzip
-
-# Forseti dependencies
-sudo apt-get install -y libffi-dev libssl-dev libmysqlclient-dev python-pip python-dev build-essential
-
-USER=ubuntu
-USER_HOME=/home/ubuntu
+sudo apt-get update -y
+sudo apt-get --assume-yes install google-cloud-sdk git unzip
 
 # Install fluentd if necessary.
 FLUENTD=$(ls /usr/sbin/google-fluentd)
@@ -31,9 +28,13 @@ cd forseti-security
 git fetch --all
 git checkout ${forseti_version}
 
+# Forseti host dependencies
+sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)
+
 # Forseti dependencies
 pip install --upgrade pip==9.0.3
 pip install -q --upgrade setuptools wheel
+pip install -q --upgrade -r requirements.txt
 
 # Install tracing libraries
 pip install .[tracing]

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Env variables
+USER=ubuntu
+USER_HOME=/home/ubuntu
+
 # forseti_conf_server digest: ${forseti_conf_server_checksum}
 # This digest is included in the startup script to rebuild the Forseti server VM
 # whenever the server configuration changes.
@@ -8,17 +12,14 @@
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 sudo apt-get update -y
-sudo apt-get --assume-yes install google-cloud-sdk
-
-# Env variables
-USER_HOME=/home/ubuntu
+sudo apt-get --assume-yes install google-cloud-sdk git unzip
 
 # Install fluentd if necessary.
 FLUENTD=$(ls /usr/sbin/google-fluentd)
 if [ -z "$FLUENTD" ]; then
-      cd $USER_HOME
-      curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
-      bash install-logging-agent.sh
+    cd $USER_HOME
+    curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
+    bash install-logging-agent.sh
 fi
 
 # Check whether Cloud SQL proxy is installed.
@@ -39,9 +40,6 @@ git clone ${forseti_repo_url}
 cd forseti-security
 git fetch --all
 git checkout ${forseti_version}
-
-# Forseti Host Setup
-sudo apt-get install -y git unzip
 
 # Forseti host dependencies
 sudo apt-get install -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs)


### PR DESCRIPTION
The Forseti client instance was installing python dependencies from Ubuntu packages and ignoring the dependency lists from the forseti-security repositories; this divergence caused the Forseti installer to fail. In contrast the Forseti server was respecting the pip requirements file and was working as intended.

This commit synchronizes the client and server startup scripts and ensure that we rely package dependency from the forseti-security repository.