### PR TITLE
Add @adrienthebo and @aaron-lane to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @morgante
+* @morgante @aaron-lane @adrienthebo


### PR DESCRIPTION
When we originally added the CODEOWNERS file we only included Morgante, since CI was not yet setup. Now that we have functioning CI we can broaden the number of code reviewers for this module.