### PR TITLE
Disable test-kitchen colored output

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,7 @@ suites:
       command_timeout: 1800
     verifier:
       name: terraform
+      color: false
       systems:
         - name: gcp
           backend: gcp
@@ -63,6 +64,7 @@ suites:
       root_module_directory: test/fixtures/shared_vpc
     verifier:
       name: terraform
+      color: false
       systems:
         - name: shared_vpc
           backend: gcp


### PR DESCRIPTION
The kitchen-terraform verifier produces colored inspec output by default, which is green on a TTY but is flashing red within concourse.  This disables the colored output so that reviewing successful CI logs is less stressful.