### PR TITLE
Assert that expected and present rules files are present

### DIFF
--- a/test/integration/simple_example/controls/forseti.rb
+++ b/test/integration/simple_example/controls/forseti.rb
@@ -80,7 +80,10 @@ control 'forseti' do
   end
 
   describe google_storage_bucket_objects(bucket: forseti_server_storage_bucket) do
-    let(:files) do
+
+    # Enumerate the files that we expect to be present. This fixture ensures that we
+    # don't silently drop a rules file.
+    let(:expected_files) do
       %w[
         rules/audit_logging_rules.yaml
         rules/bigquery_rules.yaml
@@ -105,6 +108,18 @@ control 'forseti' do
         rules/service_account_key_rules.yaml
       ]
     end
+
+    # Enumerate the files that are present in the rules directory  This fixture ensures
+    # that we don't miss an included rules file.
+    let(:present_files) do
+      template_dir = File.expand_path(
+        "../../../../modules/rules/templates/rules",
+        __dir__
+      )
+      Dir.glob("#{template_dir}/*.yaml").map {|file| "rules/#{File.basename(file)}" }
+    end
+
+    let(:files) { expected_files | present_files }
 
     its('object_names') { should include(*files) }
   end

--- a/test/integration/simple_example/controls/server.rb
+++ b/test/integration/simple_example/controls/server.rb
@@ -417,7 +417,9 @@ control 'server' do
     end
   end
 
-  %w[
+  # Enumerate the files that we expect to be present. This fixture ensures that we
+  # don't silently drop a rules file.
+  expected_files = %w[
     audit_logging_rules.yaml
     bigquery_rules.yaml
     blacklist_rules.yaml
@@ -439,7 +441,17 @@ control 'server' do
     resource_rules.yaml
     retention_rules.yaml
     service_account_key_rules.yaml
-  ].each do |file|
+  ]
+
+  template_dir = File.expand_path("../../../../modules/rules/templates/rules", __dir__)
+
+  # Enumerate the files that are present in the rules directory. This fixture ensures
+  # that we don't miss an included rules file.
+  present_files = Dir.glob("#{template_dir}/*.yaml").map {|file| File.basename(file) }
+
+  files = expected_files | present_files
+
+  files.each do |file|
     describe file("/home/ubuntu/forseti-security/rules/#{file}") do
       it { should exist }
       it "is valid YAML" do


### PR DESCRIPTION
The rules module uploads a directory of forseti rules files, but it works off of an explicit list of files. Commit e2c7ba6c added another rules file but did not include it in the rules module; this meant that the file did not get uploaded to the GCS bucket.

To prevent this issue we run tests against an explicit list of files to make sure that we don't accidentally drop a rules file, and an enumerated list of files in the repository to make sure that we don't omit a file included in the rules directory.