### PR TITLE
Update setup.sh and cleanup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,16 +205,21 @@ For this module to work, you need the following APIs enabled on the Forseti proj
 
 - compute.googleapis.com
 - serviceusage.googleapis.com
+- cloudresourcemanager.googleapis.com
 
 ## Install
-### Create the Service Account
+### Create the Service Account and enable required APIs
 You can create the service account manually, or by running the following command:
 
 ```bash
-./helpers/setup.sh <project_id>
+# Standard setup
+./helpers/setup.sh -p <project_id> -o <org_name>
+# Shared VPC setup
+./helpers/setup.sh -p <project_id> -f <host_project_id> -o <org_name>
 ```
 
 This will create a service account called `cloud-foundation-forseti-<random_numbers>`, give it the proper roles, and download it to your current directory. Note, that using this script assumes that you are currently authenticated as a user that can create/authorize service accounts at both the organization and project levels.
+This script will also activate necessary APIs required for terraform to run.
 
 ### Terraform
 Be sure you have the correct Terraform version (0.11.x), you can choose the binary here:
@@ -237,7 +242,12 @@ More information about Domain Wide Delegation can be found [here](https://develo
 ### Cleanup
 Remember to cleanup the service account used to install Forseti either manually, or by running the command:
 
-`./scripts/cleanup.sh <project_id> <service_account_id>`
+```bash
+# Standard setup
+./helpers/cleanup.sh -p <project_id> -o <org_name> -s <service_account_name>
+# Shared VPC setup
+./helpers/cleanup.sh -p <project_id> -f <host_project_id> -o <org_name> -s <service_account_name>
+```
 
 This will deprovision and delete the service account, and then delete the credentials file.
 

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ Remember to cleanup the service account used to install Forseti either manually,
 
 ```bash
 # Standard setup
-./helpers/cleanup.sh -p <project_id> -o <org_name> -s <service_account_name>
+./helpers/cleanup.sh -p <project_id> -s <service_account_name>
 # Shared VPC setup
-./helpers/cleanup.sh -p <project_id> -f <host_project_id> -o <org_name> -s <service_account_name>
+./helpers/cleanup.sh -p <project_id> -f <host_project_id> -s <service_account_name>
 ```
 
 This will deprovision and delete the service account, and then delete the credentials file.

--- a/helpers/cleanup.sh
+++ b/helpers/cleanup.sh
@@ -13,8 +13,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Usage info
+show_help() {
+cat << EOF
+Usage: ${0##*/} [-p PROJECT_ID] [-f HOST_PROJECT] [-o ORG_ID]
+Remove service account created by setup.sh script.
 
-PROJECT_ID="$(gcloud projects list --format="value(projectId)" --filter="$1")"
+    -p PROJECT_ID         project id where service account will be created.
+    -s SERVICE ACCOUNT    service account name.
+    -f HOST_PROJECT       id of a project holding shared vpc.
+    -o ORG_ID             organization id.
+    -h                    this help.
+Example: ./cleanup.sh -p test-project-1 -s cloud-foundation-forseti -o organization.com
+EOF
+}
+
+# Initialize opt variables:
+project_id=""
+host_project=""
+service_account_id=""
+org=""
+
+OPTIND=1
+while getopts ":h:p:s:f:o:" opt; do
+    case $opt in
+        h)
+            show_help
+            exit 0
+            ;;
+        p)  project_id=$OPTARG
+            ;;
+        s)  service_account_id=$OPTARG
+            ;;
+        f)  host_project=$OPTARG
+            ;;
+        o)  org=$OPTARG
+            ;;
+        *)
+            show_help >&2
+            exit 1
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"   # Discard the options and sentinel --
+
+if [[ $project_id == "" ]];
+then
+    echo "ERROR -p option is mandatory"
+    exit 1
+fi
+
+if [[ $service_account_id == "" ]];
+then
+    echo "ERROR -s option is mandatory"
+    exit 1
+fi
+
+PROJECT_ID="$(gcloud projects list --format="value(projectId)" --filter="${project_id}")"
 
 if [[ $PROJECT_ID == "" ]];
 then
@@ -23,7 +78,7 @@ then
 fi
 
 ORG_ID="$(gcloud projects describe "${PROJECT_ID}" --flatten=parent.id | grep -Eo "\d+")"
-SERVICE_ACCOUNT_ID="$(gcloud iam service-accounts list --format="value(email)" | grep -Eo "$2@${PROJECT_ID}.iam.gserviceaccount.com")"
+SERVICE_ACCOUNT_ID="$(gcloud iam service-accounts list --format="value(email)" --project="${PROJECT_ID}" | grep -Eo "${service_account_id}@${PROJECT_ID}.iam.gserviceaccount.com")"
 KEY_FILE="${PWD}/credentials.json"
 
 if [[ $SERVICE_ACCOUNT_ID == "" ]];
@@ -32,11 +87,26 @@ then
     exit 1;
 fi
 
+if [[ ${host_project} != "" ]];
+then
+    HOST_PROJECT_ID="$(gcloud projects list --format="value(projectId)" --filter="$host_project")"
+    if [[ ${HOST_PROJECT_ID} == "" ]];
+    then
+        echo  "ERROR the specified host project wasn't found."
+        exit 1
+    fi
+fi
+
 echo "Removing permissions..."
 
 gcloud organizations remove-iam-policy-binding "${ORG_ID}" \
     --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
     --role="roles/resourcemanager.organizationAdmin" \
+    --user-output-enabled false
+
+gcloud organizations remove-iam-policy-binding "${ORG_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --role="roles/iam.securityReviewer" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
@@ -56,12 +126,12 @@ gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
-    --role="roles/serviceusage.serviceUsageAdmin" \
+    --role="roles/iam.serviceAccountAdmin" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
-    --role="roles/iam.serviceAccountAdmin" \
+    --role="roles/serviceusage.serviceUsageAdmin" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
@@ -74,9 +144,26 @@ gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
     --role="roles/storage.admin" \
     --user-output-enabled false
 
+gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --role="roles/cloudsql.admin" \
+    --user-output-enabled false
+
+if [[ $HOST_PROJECT_ID != "" ]];
+then
+    gcloud projects remove-iam-policy-binding "${HOST_PROJECT_ID}" \
+        --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+        --role="roles/compute.securityAdmin" \
+        --user-output-enabled false
+
+    gcloud projects remove-iam-policy-binding "${HOST_PROJECT_ID}" \
+        --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+        --role="roles/compute.networkAdmin" \
+        --user-output-enabled false
+fi
+
 gcloud iam service-accounts delete "${SERVICE_ACCOUNT_ID}" \
     --quiet
-
 rm -rf "$KEY_FILE"
 
 echo "All done."

--- a/helpers/cleanup.sh
+++ b/helpers/cleanup.sh
@@ -32,7 +32,6 @@ EOF
 project_id=""
 host_project=""
 service_account_id=""
-org=""
 
 OPTIND=1
 while getopts ":h:p:s:f:o:" opt; do
@@ -46,8 +45,6 @@ while getopts ":h:p:s:f:o:" opt; do
         s)  service_account_id=$OPTARG
             ;;
         f)  host_project=$OPTARG
-            ;;
-        o)  org=$OPTARG
             ;;
         *)
             show_help >&2

--- a/test/integration/shared_vpc/inspec.yml
+++ b/test/integration/shared_vpc/inspec.yml
@@ -21,7 +21,8 @@ summary: An InSpec Compliance Profile For Forseti in GCP
 
 depends:
   - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/master.tar.gz
+    git: https://github.com/inspec/inspec-gcp.git
+    tag: v0.10.0
 
 attributes:
   - name: network_project

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -47,4 +47,4 @@ attributes:
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: '~> 0.9.0'
+    tag: v0.10.0


### PR DESCRIPTION
This PR fixes setup.sh and cleanup.sh to:
1. Handle shared-vpc use case
2. Update roles on SA account
3. Enable necessary services on project in order for terraform to run without problems 