### PR TITLE
Update `forseti_version` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then perform the following commands on the config folder:
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/GoogleCloudPlatform/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"0 */2 * * *"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.11.1"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.12.0"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | string | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | string | `"true"` | no |
 | group\_enabled | Group scanner enabled. | string | `"true"` | no |


### PR DESCRIPTION
We didn't auto-generate the README.md variables and outputs
documentation when we updated the `forseti_version` variable; this
corrects the omission.