### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
-## [v1.3.0]
+## [v1.3.0] - 2019-03-14
 1.3.0 is a backwards compatible feature release. This module release supports Forseti v2.13.0.
 
 ### ADDED
@@ -17,7 +17,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### CHANGED
 - Changed `forseti_version` default to v2.13.0. [#73]
 
-## [v1.2.0]
+## [v1.2.0] - 2019-02-28
 1.2.0 is a backwards compatible feature and bugfix release. This module release supports Forseti v2.12.0.
 
 ### ADDED
@@ -31,13 +31,13 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - `terraform destroy` now removes non-empty CAI export buckets [#56]
 - Add missing `kms_rules.yaml` rules file. [#64]
 
-## [v1.1.1]
+## [v1.1.1] - 2019-02-15
 1.1.1 is a backward compatible feature release. This module release supports Forseti v2.11.1.
 
 ### CHANGED
 - Update forseti_version to v2.11.1. [#59]
 
-## [v1.1.0]
+## [v1.1.0] - 2019-02-15
 1.1.0 is a backward compatible feature release. This module release supports Forseti v2.11.0.
 
 ### ADDED
@@ -52,12 +52,12 @@ Extending the adopted spec, each change should have a link to its corresponding 
 - Fix cron default frequency to be every 2 hours. [#47]
 - Update forseti_version to v2.11.0. [#58]
 
-## [v1.0.0]
+## [v1.0.0] - 2019-01-29
 1.0.0 is a backwards incompatible release and is a full rewrite of the module.
 ### CHANGED
 - Terraform now installs and manages all Forseti resources instead of using the Deployment Manager. [#33]
 
-## [v0.1.0]
+## [v0.1.0] - 2018-09-13
 ### ADDED
 - This is the initial release of the Forseti module.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
+## [v1.3.0]
+1.3.0 is a backwards compatible feature release. This module release supports Forseti v2.13.0.
+
+### ADDED
+- Added server service account to the `roles/bigquery.metadataViewer` role. [#71]
+
+### CHANGED
+- Changed `forseti_version` default to v2.13.0. [#73]
+
 ## [v1.2.0]
 1.2.0 is a backwards compatible feature and bugfix release. This module release supports Forseti v2.12.0.
 
@@ -52,12 +61,15 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### ADDED
 - This is the initial release of the Forseti module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.3.0...HEAD
 [v1.0.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v0.1.0...v1.0.0
 [v1.1.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.0.0...v1.1.0
 [v1.1.1]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.1.0...v1.1.1
 [v1.2.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.1.1...v1.2.0
+[v1.3.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.2.0...v1.3.0
 
+[#73]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/73
+[#71]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/71
 [#67]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/67
 [#61]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/61
 [#64]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/64

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then perform the following commands on the config folder:
 | forseti\_home | Forseti installation directory | string | `"$USER_HOME/forseti-security"` | no |
 | forseti\_repo\_url | Git repo for the Forseti installation | string | `"https://github.com/GoogleCloudPlatform/forseti-security"` | no |
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `"0 */2 * * *"` | no |
-| forseti\_version | The version of Forseti to install | string | `"v2.12.0"` | no |
+| forseti\_version | The version of Forseti to install | string | `"v2.13.0"` | no |
 | forwarding\_rule\_enabled | Forwarding rule scanner enabled. | string | `"false"` | no |
 | forwarding\_rule\_violations\_should\_notify | Notify for forwarding rule violations | string | `"true"` | no |
 | group\_enabled | Group scanner enabled. | string | `"true"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "gsuite_admin_email" {
 
 variable "forseti_version" {
   description = "The version of Forseti to install"
-  default     = "v2.12.0"
+  default     = "v2.13.0"
 }
 
 variable "forseti_repo_url" {


### PR DESCRIPTION
This pull request prepares the Forseti module for the v1.3.0 release. This includes updating the `forseti_version` variable default and adding a CHANGELOG.md entry for v1.3.0.

This pull request will be a draft until forseti-security v1.3.0 has been released.