### PR TITLE
Add concourse tasks to repo for integration test parallelization

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 platforms:
-  - name: terraform
+  - name: local
 
 provisioner:
   name: terraform

--- a/test/ci/real-time-enforcer.yml
+++ b/test/ci/real-time-enforcer.yml
@@ -1,0 +1,24 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-forseti
+
+run:
+  # The real-time enforcer module is not yet implemented. When the module is
+  # ready this should be changed to run `SUITE=real-time-enforcer make test_integration`
+  path: true
+  dir: terraform-google-forseti
+
+params:
+  SUITE: "real-time-enforcer-local"
+  PROJECT_ID: PROJECT_ID
+  ORG_ID: ORG_ID
+  DOMAIN: DOMAIN
+  GSUITE_ADMIN_EMAIL: GSUITE_ADMIN_EMAIL
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  NETWORK_PROJECT: NETWORK_PROJECT
+  NETWORK: NETWORK
+  SUBNETWORK: SUBNETWORK

--- a/test/ci/shared-vpc.yml
+++ b/test/ci/shared-vpc.yml
@@ -1,0 +1,23 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-forseti
+
+run:
+  path: make
+  args: ["test_integration"]
+  dir: terraform-google-forseti
+
+params:
+  SUITE: "simple-example-local"
+  PROJECT_ID: PROJECT_ID
+  ORG_ID: ORG_ID
+  DOMAIN: DOMAIN
+  GSUITE_ADMIN_EMAIL: GSUITE_ADMIN_EMAIL
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  NETWORK_PROJECT: NETWORK_PROJECT
+  NETWORK: NETWORK
+  SUBNETWORK: SUBNETWORK

--- a/test/ci/simple-example.yml
+++ b/test/ci/simple-example.yml
@@ -1,0 +1,23 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-forseti
+
+run:
+  path: make
+  args: ["test_integration"]
+  dir: terraform-google-forseti
+
+params:
+  SUITE: "shared-vpc-local"
+  PROJECT_ID: PROJECT_ID
+  ORG_ID: ORG_ID
+  DOMAIN: DOMAIN
+  GSUITE_ADMIN_EMAIL: GSUITE_ADMIN_EMAIL
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  NETWORK_PROJECT: NETWORK_PROJECT
+  NETWORK: NETWORK
+  SUBNETWORK: SUBNETWORK

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -18,7 +18,7 @@
 DELETE_AT_EXIT="$(mktemp -d)"
 finish() {
   echo 'BEGIN: finish() trap handler' >&2
-  kitchen destroy
+  kitchen destroy "$SUITE"
   [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
   echo 'END: finish() trap handler' >&2
 }
@@ -48,6 +48,7 @@ setup_environment() {
 }
 
 main() {
+  SUITE="${SUITE:-}"
   set -eu
   # Setup trap handler to auto-cleanup
   export TMPDIR="${DELETE_AT_EXIT}"
@@ -58,9 +59,9 @@ main() {
   set -x
 
   # Execute the test lifecycle
-  kitchen create
-  kitchen converge
-  kitchen verify
+  kitchen create "$SUITE"
+  kitchen converge "$SUITE"
+  kitchen verify "$SUITE"
 }
 
 # if script is being executed and not sourced.


### PR DESCRIPTION
This pull request prepares our CI configuration for running integration tests in parallel by extracting task definitions from the pipeline definition into the module, and adding a `SUITE` variable to the integration test runner to parameterize the kitchen instance under test. These two changes allow us to run multiple integration tests in parallel with the concourse `aggregate` step.

This pull request also stubs out the real-time enforcer integration test task. This stub allows us to update our concourse pipeline with the real-time-enforcer task without requiring that the module is implemented; we can do this in future commits.