### PR TITLE
Execute db_migrator.py on startup

### DIFF
--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -86,6 +86,10 @@ bash ./install/gcp/scripts/initialize_forseti_services.sh
 echo "Starting services."
 systemctl start cloudsqlproxy
 sleep 5
+
+echo "Attempting to update database schema, if necessary."
+python $USER_HOME/forseti-security/install/gcp/upgrade_tools/db_migrator.py
+
 systemctl start forseti
 echo "Success! The Forseti API server has been started."
 

--- a/test/ci/shared-vpc.yml
+++ b/test/ci/shared-vpc.yml
@@ -12,7 +12,7 @@ run:
   dir: terraform-google-forseti
 
 params:
-  SUITE: "simple-example-local"
+  SUITE: "shared-vpc-local"
   PROJECT_ID: PROJECT_ID
   ORG_ID: ORG_ID
   DOMAIN: DOMAIN

--- a/test/ci/simple-example.yml
+++ b/test/ci/simple-example.yml
@@ -12,7 +12,7 @@ run:
   dir: terraform-google-forseti
 
 params:
-  SUITE: "shared-vpc-local"
+  SUITE: "simple-example-local"
   PROJECT_ID: PROJECT_ID
   ORG_ID: ORG_ID
   DOMAIN: DOMAIN


### PR DESCRIPTION
This change is ported from:
https://github.com/GoogleCloudPlatform/forseti-security/blob/dev/deployment-templates/compute-engine/server/forseti-instance-server.py#L245-L246

The script is safe to run on every boot up of the server.