### PR TITLE
Add real-time-enforcer-roles stub

### DIFF
--- a/test/ci/real-time-enforcer-roles.yml
+++ b/test/ci/real-time-enforcer-roles.yml
@@ -1,0 +1,17 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-forseti
+
+run:
+  # The real-time enforcer roles module is not yet implemented. When the module is
+  # ready this should be changed to run `make test_integration`
+  path: true
+  dir: terraform-google-forseti
+
+params:
+  SUITE: "real-time-enforcer-roles-local"
+  ORG_ID: ORG_ID


### PR DESCRIPTION
We're adding an additional test suite to verify the real-time enforcer roles module and need a matching concourse task. This commit adds a stub task so that we can get green CI runs on pull requests that don't yet have the task; this can be enabled within the appropriate topic branch to enable CI.