### PR TITLE
add real-time-enforcer-sinks stub

### DIFF
--- a/test/ci/real-time-enforcer-sinks.yml
+++ b/test/ci/real-time-enforcer-sinks.yml
@@ -1,0 +1,17 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-forseti
+
+run:
+  # The real-time enforcer roles module is not yet implemented. When the module is
+  # ready this should be changed to run `make test_integration`
+  path: true
+  dir: terraform-google-forseti
+
+params:
+  SUITE: "real-time-enforcer-sinks-local"
+  ORG_ID: ORG_ID


### PR DESCRIPTION
We're adding an additional test suite to verify the real-time enforcer sinks modules. This test suite is explicitly sliced out of the real time enforcer module to make sure that we don't accidentally turn on an organization log sink and suddenly enforce policy outside of test scopes.