### PR TITLE
Convert setup and cleanup to use flags, add enforcer option

### DIFF
--- a/helpers/cleanup.sh
+++ b/helpers/cleanup.sh
@@ -13,68 +13,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+show_help() {
+  cat <<EOF
+Usage: ${0##*/} PROJECT_ID ORG_ID SERVICE_ACCOUNT_NAME
 
-PROJECT_ID="$(gcloud projects list --format="value(projectId)" --filter="$1")"
+Clean up resources created by the Forseti setup script.
 
-if [[ $PROJECT_ID == "" ]];
-then
-    echo "ERROR The specified project wasn't found."
-    exit 1;
+Arguments:
+
+    PROJECT_ID            The project ID where Forseti resources will be deleted.
+    ORG_ID                The organization ID to remove roles from the Forseti service account.
+    SERVICE_ACCOUNT_NAME  The service account to remove from the project and organization IAM roles.
+
+Examples:
+
+    ${0##*/} forseti-235k 22592784945 cloud-foundation-forseti-28047
+
+EOF
+}
+
+PROJECT_ID="$1"
+ORG_ID="$2"
+SERVICE_ACCOUNT_NAME="$3"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "ERROR: PROJECT_ID must be set."
+  show_help >&2
+  exit 1
 fi
 
-ORG_ID="$(gcloud projects describe "${PROJECT_ID}" --flatten=parent.id | grep -Eo "\d+")"
-SERVICE_ACCOUNT_ID="$(gcloud iam service-accounts list --format="value(email)" | grep -Eo "$2@${PROJECT_ID}.iam.gserviceaccount.com")"
+if [[ -z "$ORG_ID" ]]; then
+  echo "ERROR: ORG_ID must be set."
+  show_help >&2
+  exit 1
+fi
+
+if [[ -z "$SERVICE_ACCOUNT_NAME" ]]; then
+  echo "ERROR: SERVICE_ACCOUNT_NAME must be set."
+  show_help >&2
+  exit 1
+fi
+
+SERVICE_ACCOUNT_EMAIL="$SERVICE_ACCOUNT_NAME@${PROJECT_ID}.iam.gserviceaccount.com"
 KEY_FILE="${PWD}/credentials.json"
 
-if [[ $SERVICE_ACCOUNT_ID == "" ]];
-then
-    echo "ERROR The specified service account wasn't found."
-    exit 1;
+# Ensure that we can fetch the IAM policy on the Forseti project.
+if ! gcloud projects get-iam-policy "$PROJECT_ID" 2>&- 1>&-; then
+  echo "ERROR: Unable to fetch IAM policy on project $PROJECT_ID."
+  exit 1
 fi
 
-echo "Removing permissions..."
+# Ensure that we can fetch the IAM policy on the GCP organization.
+if ! gcloud organizations get-iam-policy "$ORG_ID" 2>&- 1>&-; then
+  echo "ERROR: Unable to fetch IAM policy on organization $ORG_ID."
+  exit 1
+fi
+
+# Ensure that we can query the service account.
+if ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" 2>&- 1>&-; then
+  echo "ERROR: Unable to fetch service account $SERVICE_ACCOUNT_EMAIL."
+  exit 1
+fi
+
+echo "Removing permissions from $SERVICE_ACCOUNT_EMAIL on organization $ORG_ID ..."
 
 gcloud organizations remove-iam-policy-binding "${ORG_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/resourcemanager.organizationAdmin" \
     --user-output-enabled false
 
+echo "Removing permissions from $SERVICE_ACCOUNT_EMAIL on project $PROJECT_ID ..."
+
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/compute.instanceAdmin" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/compute.networkViewer" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/compute.securityAdmin" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/serviceusage.serviceUsageAdmin" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/iam.serviceAccountAdmin" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/iam.serviceAccountUser" \
     --user-output-enabled false
 
 gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/storage.admin" \
     --user-output-enabled false
 
-gcloud iam service-accounts delete "${SERVICE_ACCOUNT_ID}" \
+gcloud iam service-accounts delete "${SERVICE_ACCOUNT_EMAIL}" \
     --quiet
 
 rm -rf "$KEY_FILE"

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -13,25 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+show_help() {
+  cat <<EOF
+Usage: ${0##*/} PROJECT_ID ORG_ID
 
-PROJECT_ID="$(gcloud projects list --format="value(projectId)" --filter="$1")"
+Generate a service account with the IAM roles needed to run the Forseti Terraform module.
 
-if [[ $PROJECT_ID == "" ]];
-then
-    echo "ERROR The specified project wasn't found."
-    exit 1;
+Arguments:
+
+    PROJECT_ID    The project ID where Forseti resources will be created.
+    ORG_ID        The organization ID that Forseti will be monitoring.
+
+Examples:
+
+    ${0##*/} forseti-235k 22592784945
+
+EOF
+}
+
+PROJECT_ID="$1"
+ORG_ID="$2"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "ERROR: PROJECT_ID must be set."
+  show_help >&2
+  exit 1
 fi
 
-ORG_ID="$(gcloud organizations list --format="value(ID)" --filter="$2")"
+if [[ -z "$ORG_ID" ]]; then
+  echo "ERROR: ORG_ID must be set."
+  show_help >&2
+  exit 1
+fi
 
-if [[ $ORG_ID == "" ]];
-then
-    echo "ERROR the specified organization id wasn't found."
-    exit 1;
+# Ensure that we can fetch the IAM policy on the Forseti project.
+if ! gcloud projects get-iam-policy "$PROJECT_ID" 2>&- 1>&-; then
+  echo "ERROR: Unable to fetch IAM policy on project $PROJECT_ID."
+  exit 1
+fi
+
+# Ensure that we can fetch the IAM policy on the GCP organization.
+if ! gcloud organizations get-iam-policy "$ORG_ID" 2>&- 1>&-; then
+  echo "ERROR: Unable to fetch IAM policy on organization $ORG_ID."
+  exit 1
 fi
 
 SERVICE_ACCOUNT_NAME="cloud-foundation-forseti-${RANDOM}"
-SERVICE_ACCOUNT_ID="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 STAGING_DIR="${PWD}"
 KEY_FILE="${STAGING_DIR}/credentials.json"
 
@@ -43,53 +71,53 @@ gcloud iam service-accounts \
 echo "Downloading key to credentials.json..."
 
 gcloud iam service-accounts keys create "${KEY_FILE}" \
-    --iam-account "${SERVICE_ACCOUNT_ID}" \
+    --iam-account "${SERVICE_ACCOUNT_EMAIL}" \
     --user-output-enabled false
 
 echo "Applying permissions for org $ORG_ID and project $PROJECT_ID..."
 
 gcloud organizations add-iam-policy-binding "${ORG_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/resourcemanager.organizationAdmin" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/compute.instanceAdmin" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/compute.networkViewer" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/compute.securityAdmin" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/iam.serviceAccountAdmin" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/serviceusage.serviceUsageAdmin" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/iam.serviceAccountUser" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/storage.admin" \
     --user-output-enabled false
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/cloudsql.admin" \
     --user-output-enabled false
 


### PR DESCRIPTION
This commit adds the ability to grant and revoke IAM permissions needed to run the real time enforcer service account. Because bash has weak support for mixed options and arguments this commit uses flags for all values for ease of development.