### PR TITLE
Export children logs from organization sink

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -195,5 +195,5 @@ suites:
       name: terraform
       color: false
       systems:
-        - name: shared_vpc
+        - name: gcloud
           backend: local

--- a/modules/real_time_enforcer_organization_sink/main.tf
+++ b/modules/real_time_enforcer_organization_sink/main.tf
@@ -31,9 +31,11 @@ resource "google_pubsub_topic" "main" {
 }
 
 resource "google_logging_organization_sink" "main" {
-  name                   = "real-time-enforcer-log-sink-${random_string.main.result}"
-  org_id                 = "${var.org_id}"
-  destination            = "pubsub.googleapis.com/projects/${var.pubsub_project_id}/topics/${google_pubsub_topic.main.name}"
+  name             = "real-time-enforcer-log-sink-${random_string.main.result}"
+  org_id           = "${var.org_id}"
+  destination      = "pubsub.googleapis.com/projects/${var.pubsub_project_id}/topics/${google_pubsub_topic.main.name}"
+  include_children = "true"
+
   filter                 = <<EOD
 protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog
 severity != ERROR

--- a/test/integration/real_time_enforcer_sinks/controls/sinks.rb
+++ b/test/integration/real_time_enforcer_sinks/controls/sinks.rb
@@ -21,13 +21,13 @@ project_sink_name = attribute('project_sink_name')
 project_topic     = attribute('project_topic')
 
 control 'sinks' do
-  describe command("gcloud logging sinks list --organization #{org_id} --filter='name:#{org_sink_name}' --format=json") do
+  describe command("gcloud logging sinks describe #{org_sink_name} --organization #{org_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 
     let(:data) do
       if subject.exit_status == 0
-        JSON.parse(subject.stdout, symbolize_names: true).first
+        JSON.parse(subject.stdout, symbolize_names: true)
       else
         {}
       end
@@ -36,15 +36,19 @@ control 'sinks' do
     it "exports logs to the enforcer topic" do
       expect(data[:destination]).to eq "pubsub.googleapis.com/projects/#{pubsub_project_id}/topics/#{org_topic}"
     end
+
+    it "includes children logs" do
+      expect(data[:includeChildren]).to be true
+    end
   end
 
-  describe command("gcloud logging sinks list --project #{sink_project_id} --filter='name:#{project_sink_name}' --format=json") do
+  describe command("gcloud logging sinks describe #{project_sink_name} --project #{sink_project_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 
     let(:data) do
       if subject.exit_status == 0
-        JSON.parse(subject.stdout, symbolize_names: true).first
+        JSON.parse(subject.stdout, symbolize_names: true)
       else
         {}
       end


### PR DESCRIPTION
The `google_organization_logging_sink` was not exporting logs from
children nodes; this omission meant that we were throwing away most of
the logs relevant to the real time enforcer. This commit fixes the
omission.