### PR TITLE
Target firewall rule tests at a specific forseti instance

### DIFF
--- a/examples/shared_vpc/README.md
+++ b/examples/shared_vpc/README.md
@@ -39,5 +39,6 @@ This example illustrates how to set up a Forseti installation with shared VPC.
 | project\_id | ID of the service project |
 | region | Region in which server and client will be deployed |
 | subnetwork | Subnetwork where server and client will be deployed |
+| suffix | The random suffix appended to Forseti resources |
 
 [^]: (autogen_docs_end)

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+output "suffix" {
+  description = "The random suffix appended to Forseti resources"
+  value       = "${module.forseti.suffix}"
+}
+
 output "project_id" {
   description = "ID of the service project"
   value       = "${var.project_id}"

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -29,5 +29,6 @@ This example illustrates how to set up a minimal Forseti installation.
 | forseti-server-vm-ip | Forseti Server VM private IP address |
 | forseti-server-vm-name | Forseti Server VM name |
 | forseti-server-vm-public-ip | Forseti Client VM public IP address |
+| suffix | The random suffix appended to Forseti resources |
 
 [^]: (autogen_docs_end)

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+output "suffix" {
+  description = "The random suffix appended to Forseti resources"
+  value       = "${module.forseti-install-simple.suffix}"
+}
+
 output "forseti-client-vm-name" {
   description = "Forseti Client VM name"
   value       = "${module.forseti-install-simple.forseti-client-vm-name}"

--- a/test/fixtures/shared_vpc/outputs.tf
+++ b/test/fixtures/shared_vpc/outputs.tf
@@ -98,3 +98,8 @@ output "forseti-server-service-account" {
   description = "Forseti Server service account"
   value       = "${module.forseti-shared-vpc.forseti-server-service-account}"
 }
+
+output "suffix" {
+  description = "The random suffix appended to Forseti resources"
+  value       = "${module.forseti-shared-vpc.suffix}"
+}

--- a/test/fixtures/simple_example/outputs.tf
+++ b/test/fixtures/simple_example/outputs.tf
@@ -73,3 +73,8 @@ output "org_id" {
   description = "A forwarded copy of `org_id` for InSpec"
   value       = "${var.org_id}"
 }
+
+output "suffix" {
+  description = "The random suffix appended to Forseti resources"
+  value       = "${module.forseti-install-simple.suffix}"
+}

--- a/test/integration/real_time_enforcer/inspec.yml
+++ b/test/integration/real_time_enforcer/inspec.yml
@@ -26,6 +26,10 @@ attributes:
 - name: enforcer_project_id
   required: true
   type: string
+- name: network_project
+  required: false
+  type: string
+  default: ''
 
 # Forseti client attributes
 - name: forseti-client-vm-name

--- a/test/integration/shared_vpc/controls/shared_vpc.rb
+++ b/test/integration/shared_vpc/controls/shared_vpc.rb
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-title 'Forseti Terraform GCP Test Suite for Shared VPC setup'
 
-project_id              = attribute("project_id")
-network_project         = attribute("network_project")
-forseti_server_vm_name  = attribute("forseti-server-vm-name")
-forseti_server_vm_ip    = attribute("forseti-server-vm-ip")
-forseti_client_vm_name  = attribute("forseti-client-vm-name")
-region                  = attribute("region")
-network                 = attribute("network")
+project_id      = attribute("project_id")
+network_project = attribute("network_project")
 
 control 'forseti-service-project' do
-  impact 1.0
-  title 'test forseti project'
+  title 'Forseti service project'
   describe google_compute_project_info(project: project_id) do
     its('xpn_project_status') { should eq 'UNSPECIFIED_XPN_PROJECT_STATUS' }
     its('name') { should eq project_id }
@@ -32,41 +25,9 @@ control 'forseti-service-project' do
 end
 
 control 'forseti-shared-project' do
-  impact 1.0
-  title 'test shared project'
+  title 'Forseti host project'
   describe google_compute_project_info(project: network_project) do
     its('xpn_project_status') { should eq 'HOST' }
     its('name') { should eq network_project }
-  end
-end
-
-control 'forseti-server' do
-  impact 1.0
-  title 'test forseti server'
-  describe google_compute_instance(project: project_id,  zone: "#{region}-c", name: forseti_server_vm_name) do
-    it { should exist }
-    its('has_disks_encrypted_with_csek?') { should be false }
-    its('status') { should eq 'RUNNING' }
-    its('disk_count'){should eq 1}
-  end
-end
-
-control 'forseti-client' do
-  impact 1.0
-  title 'test forset client'
-  describe google_compute_instance(project: project_id,  zone: "#{region}-c", name: forseti_client_vm_name) do
-    it { should exist }
-    its('has_disks_encrypted_with_csek?') { should be false }
-    its('status') { should eq 'RUNNING' }
-    its('disk_count'){should eq 1}
-  end
-end
-
-control 'forseti-shared-firewall' do
-  google_compute_firewalls(project: network_project).where(firewall_name: /forseti-/).firewall_names.each do |firewall_name|
-    describe google_compute_firewall(project: network_project, name: firewall_name) do
-      its('direction') { should eq "INGRESS" }
-      its('network') { should eq "https://www.googleapis.com/compute/v1/projects/#{network_project}/global/networks/#{network}" }
-    end
   end
 end

--- a/test/integration/shared_vpc/inspec.yml
+++ b/test/integration/shared_vpc/inspec.yml
@@ -37,6 +37,9 @@ attributes:
     required: true
     description: 'Forseti project id. This is a service project.'
     type: string
+  - name: suffix
+    required: true
+    type: string
   - name: forseti-server-vm-name
     required: true
     description: "Forseti server name"

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -17,7 +17,14 @@ attributes:
 - name: project_id
   required: true
   type: string
+- name: network_project
+  required: false
+  type: string
+  default: ''
 - name: org_id
+  required: true
+  type: string
+- name: suffix
   required: true
   type: string
 - name: forseti-client-vm-name


### PR DESCRIPTION
Prior to this commit the forseti firewall rule integration tests would run verification on all forseti related firewall rules, even if those rules were associated with a different installation. This overly broad testing could cause tests to run against firewall rules in an instance that was being created or torn down, causing cross-test failures.

This commit amends the issue by specifically testing firewall rules from the current instance, based on the associated suffix. This change should prevent configuration leakage between instances.