### PR TITLE
Add limited retries to real time enforcer services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
+<<<<<<< HEAD
 ## [Unreleased]
 
 ### Changed
 
 - Removed Forseti resources from real time enforcer example. [#119]
 
+||||||| merged common ancestors
+=======
+## [Unreleased]
+
+### Fixed
+
+- Real time enforcer containers will restart when encountering errors. [#120]
+
+>>>>>>> Add limited retries to real time enforcer services
 ## [v1.4.0] - 2019-04-04
 
 ### Added
@@ -105,6 +115,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [v1.3.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.2.0...v1.3.0
 [v1.4.0]: https://github.com/terraform-google-modules/terraform-google-forseti/compare/v1.3.0...v1.4.0
 
+[#120]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/120
 [#119]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/119
 [#116]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/116
 [#115]: https://github.com/terraform-google-modules/terraform-google-forseti/pull/115

--- a/modules/real_time_enforcer/templates/cloud-init.yml
+++ b/modules/real_time_enforcer/templates/cloud-init.yml
@@ -34,6 +34,9 @@ write_files:
     Wants=opa-policy.service docker.service
     After=network.target opa-policy.service
 
+    StartLimitInterval=120
+    StartLimitBurst=5
+
     [Service]
     ExecStartPre=/bin/mkdir -p /var/lib/opa
     ExecStartPre=-/usr/bin/docker rm opa-server
@@ -44,6 +47,7 @@ write_files:
     ExecStopPost=-/usr/bin/docker stop opa-server
     ExecStopPost=-/usr/bin/docker rm opa-server
     Restart=always
+    RestartSec=5
 
 - path: /etc/systemd/system/enforcer.service
   permissions: 0644
@@ -53,6 +57,9 @@ write_files:
     Description=Forseti real time policy enforcer
     Wants=opa-server.service docker.service
     After=opa-server.service docker.service
+
+    StartLimitInterval=120
+    StartLimitBurst=5
 
     [Install]
     WantedBy=multi-user.target
@@ -68,6 +75,8 @@ write_files:
 
     ExecStopPost=-/usr/bin/docker stop enforcer
     ExecStopPost=-/usr/bin/docker rm enforcer
+    Restart=always
+    RestartSec=5
 
 runcmd:
 - systemctl daemon-reload


### PR DESCRIPTION
We've observed random but fairly common CI failures with the real-time-enforcer module, specifically in that the enforcer service is not running. Further inspection into one of these failures showed that the `docker pull` failed due to a network error and the service shut down. Network issues are unavoidable so we should be able to handle these situations with some resilience.

This commit updates the opa-server and enforcer systemd units to restart the services upon error, delay 5 seconds between each attempt, and to stop restarting if 5 starts occur within 120 seconds. The delay between each restart allows transient network issues to resolve, and the start limit burst prevents the service from endlessly restarting in case there's an issue that can't be recovered from through restarting.