### PR TITLE
Add CSCC findings IAM role.

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -68,6 +68,9 @@ locals {
   server_bucket_roles = [
     "roles/storage.objectAdmin",
   ]
+  server_cscc_roles = [
+    "roles/securitycenter.findingsEditor",
+  ]
 }
 
 #-------------------#
@@ -270,6 +273,13 @@ resource "google_folder_iam_member" "folder_write" {
   count  = "${var.folder_id != "" && var.enable_write ? length(local.server_write_roles) : 0}"
   role   = "${local.server_write_roles[count.index]}"
   folder = "${var.folder_id}"
+  member = "serviceAccount:${google_service_account.forseti_server.email}"
+}
+
+resource "google_organization_iam_member" "org_cscc" {
+  count  = "${var.org_id != "" && var.cscc_violations_enabled ? length(local.server_cscc_roles) : 0}"
+  role   = "${local.server_cscc_roles[count.index]}"
+  org_id = "${var.org_id}"
   member = "serviceAccount:${google_service_account.forseti_server.email}"
 }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-forseti/issues/68.

If CSCC is configured, then the Forseti server service account needs the org
role binding roles/securitycenter.findingsEditor.

Currently, users will have to create this IAM binding outside of the module.